### PR TITLE
Initialize Firebase and add onboarding flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ yarn-error.*
 
 app-example
 
-firebase.ts
+/firebase.ts

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,16 +1,34 @@
+import { useEffect, useState, createContext } from 'react';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { onAuthStateChanged } from 'firebase/auth';
 import 'react-native-reanimated';
 
+import { auth, fetchUserProfile, UserProfile } from '../scripts/firebase';
 import { useColorScheme } from '@/hooks/useColorScheme';
+
+export const UserProfileContext = createContext<UserProfile | null>(null);
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        const data = await fetchUserProfile(user.uid);
+        setProfile(data);
+      } else {
+        setProfile(null);
+      }
+    });
+    return unsubscribe;
+  }, []);
 
   if (!loaded) {
     // Async font loading only occurs in development.
@@ -18,12 +36,15 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <UserProfileContext.Provider value={profile}>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="onboarding" options={{ title: 'Onboarding' }} />
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </UserProfileContext.Provider>
   );
 }

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { auth, writeUserProfile, UserProfile } from '../../scripts/firebase';
+
+export default function OnboardingScreen() {
+  const [grade, setGrade] = useState('');
+  const [desiredSchool, setDesiredSchool] = useState('');
+  const [personality, setPersonality] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async () => {
+    const user = auth.currentUser;
+    if (!user) return;
+    const profile: UserProfile = { grade, desiredSchool, personality };
+    await writeUserProfile(user.uid, profile);
+    router.replace('/');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Grade</Text>
+      <TextInput
+        style={styles.input}
+        value={grade}
+        onChangeText={setGrade}
+        placeholder="e.g. 3rd"
+      />
+      <Text style={styles.label}>Desired School</Text>
+      <TextInput
+        style={styles.input}
+        value={desiredSchool}
+        onChangeText={setDesiredSchool}
+        placeholder="School name"
+      />
+      <Text style={styles.label}>Personality</Text>
+      <TextInput
+        style={styles.input}
+        value={personality}
+        onChangeText={setPersonality}
+        placeholder="Result"
+      />
+      <Button title="Submit" onPress={handleSubmit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center',
+  },
+  label: {
+    marginBottom: 4,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+});

--- a/scripts/firebase.ts
+++ b/scripts/firebase.ts
@@ -1,0 +1,32 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getDatabase, ref, set, get } from 'firebase/database';
+
+const firebaseConfig = {
+  apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.EXPO_PUBLIC_FIREBASE_DB_URL,
+  projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getDatabase(app);
+
+export interface UserProfile {
+  grade: string;
+  desiredSchool: string;
+  personality: string;
+}
+
+export async function writeUserProfile(uid: string, profile: UserProfile) {
+  return set(ref(db, `users/${uid}`), profile);
+}
+
+export async function fetchUserProfile(uid: string): Promise<UserProfile | null> {
+  const snapshot = await get(ref(db, `users/${uid}`));
+  return snapshot.exists() ? (snapshot.val() as UserProfile) : null;
+}


### PR DESCRIPTION
## Summary
- add Firebase init with Auth and Realtime Database helpers
- implement onboarding screen to capture user profile and save to DB
- load authenticated user's profile in root layout and expose via context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2d77c204832bb130529d25d84057