### PR TITLE
feat: add Supabase event logging and retry utility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+EXPO_PUBLIC_ENV=development
+
+EXPO_PUBLIC_SUPABASE_URL_DEV=https://your-dev.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY_DEV=your-dev-anon-key
+EXPO_PUBLIC_SUPABASE_EVENT_TABLE_DEV=event_logs_dev
+
+EXPO_PUBLIC_SUPABASE_URL_PROD=https://your-prod.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY_PROD=your-prod-anon-key
+EXPO_PUBLIC_SUPABASE_EVENT_TABLE_PROD=event_logs

--- a/README.md
+++ b/README.md
@@ -23,3 +23,19 @@ AIモデル
 その他
 •	Google Vision API または Microsoft提供のOCR (検討中) 
 
+### Supabase 環境変数
+開発と本番でテーブル名やキーが切り替えられるよう、以下の環境変数を設定してください。
+
+```
+EXPO_PUBLIC_ENV=development # または production
+
+EXPO_PUBLIC_SUPABASE_URL_DEV=...
+EXPO_PUBLIC_SUPABASE_ANON_KEY_DEV=...
+EXPO_PUBLIC_SUPABASE_EVENT_TABLE_DEV=...
+
+EXPO_PUBLIC_SUPABASE_URL_PROD=...
+EXPO_PUBLIC_SUPABASE_ANON_KEY_PROD=...
+EXPO_PUBLIC_SUPABASE_EVENT_TABLE_PROD=...
+```
+
+`.env` を作成し、上記の値を設定してからアプリを実行してください。

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,6 +5,9 @@ import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { ChatSendButton } from '../../components/ChatSendButton';
+import { TaggingButton } from '../../components/TaggingButton';
+import { ReportButton } from '../../components/ReportButton';
 
 export default function HomeScreen() {
   return (
@@ -50,6 +53,12 @@ export default function HomeScreen() {
           <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
           <ThemedText type="defaultSemiBold">app-example</ThemedText>.
         </ThemedText>
+      </ThemedView>
+      <ThemedView style={styles.stepContainer}>
+        <ThemedText type="subtitle">Event Logging Demo</ThemedText>
+        <ChatSendButton />
+        <TaggingButton />
+        <ReportButton />
       </ThemedView>
     </ParallaxScrollView>
   );

--- a/components/ChatSendButton.tsx
+++ b/components/ChatSendButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Button, Alert } from 'react-native';
+import { logEvent } from '../scripts/supabase';
+
+export function ChatSendButton() {
+  const handlePress = async () => {
+    try {
+      await logEvent('chat_send', { message: 'Hello' });
+    } catch (error) {
+      console.error(error);
+      Alert.alert('Error', 'Failed to log chat event');
+    }
+  };
+
+  return <Button title="Send Chat" onPress={handlePress} />;
+}

--- a/components/ReportButton.tsx
+++ b/components/ReportButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Button, Alert } from 'react-native';
+import { logEvent } from '../scripts/supabase';
+
+export function ReportButton() {
+  const handlePress = async () => {
+    try {
+      await logEvent('report_create', { reportId: Date.now() });
+    } catch (error) {
+      console.error(error);
+      Alert.alert('Error', 'Failed to log report event');
+    }
+  };
+
+  return <Button title="Create Report" onPress={handlePress} />;
+}

--- a/components/TaggingButton.tsx
+++ b/components/TaggingButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Button, Alert } from 'react-native';
+import { logEvent } from '../scripts/supabase';
+
+export function TaggingButton() {
+  const handlePress = async () => {
+    try {
+      await logEvent('tag_add', { tag: 'example' });
+    } catch (error) {
+      console.error(error);
+      Alert.alert('Error', 'Failed to log tag event');
+    }
+  };
+
+  return <Button title="Add Tag" onPress={handlePress} />;
+}

--- a/scripts/retry.ts
+++ b/scripts/retry.ts
@@ -1,0 +1,9 @@
+export async function withRetry<T>(fn: () => Promise<T>, retries = 3, delay = 500): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries <= 0) throw error;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return withRetry(fn, retries - 1, delay * 2);
+  }
+}

--- a/scripts/supabase.ts
+++ b/scripts/supabase.ts
@@ -1,0 +1,46 @@
+import { withRetry } from './retry';
+
+const ENV = process.env.EXPO_PUBLIC_ENV === 'production' ? 'production' : 'development';
+
+const SUPABASE_URL =
+  ENV === 'production'
+    ? process.env.EXPO_PUBLIC_SUPABASE_URL_PROD!
+    : process.env.EXPO_PUBLIC_SUPABASE_URL_DEV!;
+const SUPABASE_KEY =
+  ENV === 'production'
+    ? process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY_PROD!
+    : process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY_DEV!;
+const EVENT_TABLE =
+  ENV === 'production'
+    ? process.env.EXPO_PUBLIC_SUPABASE_EVENT_TABLE_PROD!
+    : process.env.EXPO_PUBLIC_SUPABASE_EVENT_TABLE_DEV!;
+
+async function insert(table: string, values: Record<string, any>) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_KEY,
+      Authorization: `Bearer ${SUPABASE_KEY}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(values),
+  });
+
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || 'Supabase insert failed');
+  }
+
+  return res.json();
+}
+
+export async function logEvent(action: string, payload: Record<string, any>) {
+  return withRetry(() =>
+    insert(EVENT_TABLE, {
+      action,
+      payload,
+      created_at: new Date().toISOString(),
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- add Supabase client and retry helper
- log events for chat sending, tagging, and report creation
- document environment variables for dev and prod

## Testing
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2f660818832b9eaf4e8211df09ea