### PR TITLE
feat: add lightweight topic classifier

### DIFF
--- a/scripts/api/commander.ts
+++ b/scripts/api/commander.ts
@@ -1,0 +1,28 @@
+import OpenAI from 'openai';
+import { AgentType, AGENT_TYPES } from './types';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const DEFAULT_AGENT: AgentType = 'tutor';
+const MODEL = process.env.TOPIC_MODEL || 'gpt-4o-mini';
+
+export async function classifyTopic(
+  text: string,
+  fallback: AgentType = DEFAULT_AGENT,
+): Promise<AgentType> {
+  try {
+    const prompt = `Classify the user's request into one of: tutor, counselor, planner.\n\nText: ${text}\nLabel:`;
+    const res = await client.responses.create({
+      model: MODEL,
+      input: prompt,
+      max_output_tokens: 1,
+    });
+
+    const label = res.output_text?.trim().toLowerCase();
+    if (AGENT_TYPES.includes(label as AgentType)) {
+      return label as AgentType;
+    }
+  } catch (err) {
+    console.error('Topic classification failed:', err);
+  }
+  return fallback;
+}

--- a/scripts/api/types.ts
+++ b/scripts/api/types.ts
@@ -1,0 +1,3 @@
+export type AgentType = 'tutor' | 'counselor' | 'planner';
+
+export const AGENT_TYPES: AgentType[] = ['tutor', 'counselor', 'planner'];


### PR DESCRIPTION
## Summary
- add `AgentType` type for tutor/counselor/planner
- implement `classifyTopic` using small OpenAI model with fallback to tutor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e336bc760832b825f08219b08fc41