### PR TITLE
feat: add multi-agent chat store and screen

### DIFF
--- a/app/(tabs)/chat/new.tsx
+++ b/app/(tabs)/chat/new.tsx
@@ -1,0 +1,65 @@
+import React, { useRef, useState } from 'react';
+import { View, TextInput, Button, FlatList, Text } from 'react-native';
+import { nanoid } from 'nanoid';
+
+import { classifyTopic } from '../../../scripts/api/commander';
+import { tutor } from '../../../scripts/api/tutor';
+import { counselor } from '../../../scripts/api/counselor';
+import { planner } from '../../../scripts/api/planner';
+import { AgentType } from '../../../scripts/api/types';
+import { useChatStore, ChatMessage } from '../../../store/chatStore';
+
+const agentClients: Record<AgentType, (msgs: ChatMessage[]) => Promise<string>> = {
+  tutor,
+  counselor,
+  planner,
+};
+
+export default function NewChatScreen() {
+  const threadIdRef = useRef(nanoid());
+  const threadId = threadIdRef.current;
+  const [input, setInput] = useState('');
+  const { threads, addMessage, setAgentType, createThread } = useChatStore();
+
+  if (!threads[threadId]) {
+    createThread(threadId);
+  }
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text) return;
+    addMessage(threadId, { role: 'user', content: text });
+
+    let agent = useChatStore.getState().threads[threadId].agentType;
+    if (!agent) {
+      agent = await classifyTopic(text);
+      setAgentType(threadId, agent);
+    }
+
+    const messages = useChatStore.getState().threads[threadId].messages;
+    const reply = await agentClients[agent](messages);
+    addMessage(threadId, { role: 'assistant', content: reply });
+    setInput('');
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={threads[threadId]?.messages ?? []}
+        keyExtractor={(_, idx) => idx.toString()}
+        renderItem={({ item }) => (
+          <Text>
+            {item.role}: {item.content}
+          </Text>
+        )}
+      />
+      <TextInput
+        value={input}
+        onChangeText={setInput}
+        placeholder="Type your message"
+        style={{ borderWidth: 1, borderColor: '#ccc', marginBottom: 8, padding: 8 }}
+      />
+      <Button title="Send" onPress={handleSend} />
+    </View>
+  );
+}

--- a/scripts/api/counselor.ts
+++ b/scripts/api/counselor.ts
@@ -1,0 +1,13 @@
+import OpenAI from 'openai';
+import { ChatMessage } from '../../store/chatStore';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const MODEL = process.env.COUNSELOR_MODEL || 'gpt-4o-mini';
+
+export async function counselor(messages: ChatMessage[]): Promise<string> {
+  const res = await client.responses.create({
+    model: MODEL,
+    input: messages.map((m) => ({ role: m.role, content: m.content })),
+  });
+  return res.output_text ?? '';
+}

--- a/scripts/api/planner.ts
+++ b/scripts/api/planner.ts
@@ -1,0 +1,13 @@
+import OpenAI from 'openai';
+import { ChatMessage } from '../../store/chatStore';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const MODEL = process.env.PLANNER_MODEL || 'gpt-4o-mini';
+
+export async function planner(messages: ChatMessage[]): Promise<string> {
+  const res = await client.responses.create({
+    model: MODEL,
+    input: messages.map((m) => ({ role: m.role, content: m.content })),
+  });
+  return res.output_text ?? '';
+}

--- a/scripts/api/tutor.ts
+++ b/scripts/api/tutor.ts
@@ -1,0 +1,13 @@
+import OpenAI from 'openai';
+import { ChatMessage } from '../../store/chatStore';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const MODEL = process.env.TUTOR_MODEL || 'gpt-4o-mini';
+
+export async function tutor(messages: ChatMessage[]): Promise<string> {
+  const res = await client.responses.create({
+    model: MODEL,
+    input: messages.map((m) => ({ role: m.role, content: m.content })),
+  });
+  return res.output_text ?? '';
+}

--- a/store/chatStore.ts
+++ b/store/chatStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import { AgentType } from '../scripts/api/types';
+
+export type ChatMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export interface ChatThread {
+  threadId: string;
+  agentType?: AgentType;
+  messages: ChatMessage[];
+}
+
+interface ChatState {
+  threads: Record<string, ChatThread>;
+  createThread: (threadId: string) => void;
+  addMessage: (threadId: string, message: ChatMessage) => void;
+  setAgentType: (threadId: string, agent: AgentType) => void;
+  getThread: (threadId: string) => ChatThread | undefined;
+}
+
+export const useChatStore = create<ChatState>((set, get) => ({
+  threads: {},
+  createThread: (threadId) => {
+    const existing = get().threads[threadId];
+    if (existing) return;
+    set((state) => ({
+      threads: {
+        ...state.threads,
+        [threadId]: { threadId, messages: [] },
+      },
+    }));
+  },
+  addMessage: (threadId, message) => {
+    const current = get().threads[threadId] ?? { threadId, messages: [] };
+    set((state) => ({
+      threads: {
+        ...state.threads,
+        [threadId]: {
+          ...current,
+          messages: [...current.messages, message],
+        },
+      },
+    }));
+  },
+  setAgentType: (threadId, agent) =>
+    set((state) => {
+      const thread = state.threads[threadId];
+      if (!thread) return state;
+      return {
+        threads: {
+          ...state.threads,
+          [threadId]: { ...thread, agentType: agent },
+        },
+      };
+    }),
+  getThread: (threadId) => get().threads[threadId],
+}));


### PR DESCRIPTION
## Summary
- add Zustand chat store to track threads, agents, and messages
- create OpenAI clients for tutor, counselor, and planner agents
- implement new chat screen that classifies first message and routes to agent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: expo: not found)*
- `npm install` *(fails: dependency conflict with openai and zod)*

------
https://chatgpt.com/codex/tasks/task_e_689e35286310832bbbb59a42d8aed51d