### PR TITLE
feat: add login flow with firebase auth

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,9 @@
-import { Tabs } from 'expo-router';
+import { Tabs, useRouter } from 'expo-router';
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, Button } from 'react-native';
+import { signOut } from 'firebase/auth';
+
+import { auth } from '../../scripts/firebase';
 
 import { HapticTab } from '@/components/HapticTab';
 import { IconSymbol } from '@/components/ui/IconSymbol';
@@ -10,12 +13,19 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    await signOut(auth);
+    router.replace('/login');
+  };
 
   return (
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-        headerShown: false,
+        headerShown: true,
+        headerRight: () => <Button title="Sign Out" onPress={handleSignOut} />, 
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
         tabBarStyle: Platform.select({

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, createContext } from 'react';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { onAuthStateChanged } from 'firebase/auth';
 import 'react-native-reanimated';
@@ -17,18 +17,25 @@ export default function RootLayout() {
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
   const [profile, setProfile] = useState<UserProfile | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         const data = await fetchUserProfile(user.uid);
         setProfile(data);
+        if (data) {
+          router.replace('/(tabs)');
+        } else {
+          router.replace('/onboarding');
+        }
       } else {
         setProfile(null);
+        router.replace('/login');
       }
     });
     return unsubscribe;
-  }, []);
+  }, [router]);
 
   if (!loaded) {
     // Async font loading only occurs in development.
@@ -39,6 +46,7 @@ export default function RootLayout() {
     <UserProfileContext.Provider value={profile}>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
+          <Stack.Screen name="login" options={{ headerShown: false }} />
           <Stack.Screen name="onboarding" options={{ title: 'Onboarding' }} />
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="+not-found" />

--- a/app/login/index.tsx
+++ b/app/login/index.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { useRouter } from 'expo-router';
+import { signInWithEmailAndPassword, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+
+import { auth, fetchUserProfile } from '../../scripts/firebase';
+
+export default function LoginScreen() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const navigateAfterLogin = async () => {
+    const user = auth.currentUser;
+    if (!user) return;
+    const profile = await fetchUserProfile(user.uid);
+    if (profile) {
+      router.replace('/(tabs)');
+    } else {
+      router.replace('/onboarding');
+    }
+  };
+
+  const handleEmailLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      await navigateAfterLogin();
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  const handleGoogleLogin = async () => {
+    try {
+      const provider = new GoogleAuthProvider();
+      await signInWithPopup(auth, provider);
+      await navigateAfterLogin();
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+      <Button title="Sign In" onPress={handleEmailLogin} />
+      <View style={styles.separator} />
+      <Button title="Sign In with Google" onPress={handleGoogleLogin} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+  separator: {
+    height: 12,
+  },
+  error: {
+    color: 'red',
+    marginBottom: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- add login screen with email/password and Google OAuth
- route users to onboarding or main tabs based on profile
- include sign-out action in tab headers and redirect to login

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e373b1b60832bb7087d5f3c74a31e