### PR TITLE
Add agent-specific chat screens with persistence

### DIFF
--- a/app/(tabs)/chat/counselor.tsx
+++ b/app/(tabs)/chat/counselor.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { View, TextInput, Button, FlatList, Text } from 'react-native';
+
+import { TaggingButton } from '../../../components/TaggingButton';
+import { counselor } from '../../../scripts/api/counselor';
+import { useChatStore } from '../../../store/chatStore';
+
+export default function CounselorChatScreen() {
+  const threadId = 'counselor';
+  const { threads, addMessage, loadThread } = useChatStore();
+  const thread = threads[threadId];
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    loadThread(threadId);
+  }, [threadId, loadThread]);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text) return;
+    await addMessage(threadId, { role: 'user', content: text });
+    const messages = useChatStore.getState().threads[threadId].messages;
+    const reply = await counselor(messages);
+    await addMessage(threadId, { role: 'assistant', content: reply });
+    setInput('');
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={thread?.messages ?? []}
+        keyExtractor={(_, idx) => idx.toString()}
+        renderItem={({ item }) => (
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <Text style={{ flex: 1 }}>
+              {item.role}: {item.content}
+            </Text>
+            <TaggingButton />
+          </View>
+        )}
+      />
+      <TextInput
+        value={input}
+        onChangeText={setInput}
+        placeholder="Type your message"
+        style={{ borderWidth: 1, borderColor: '#ccc', marginBottom: 8, padding: 8 }}
+      />
+      <Button title="Send" onPress={handleSend} />
+    </View>
+  );
+}
+

--- a/app/(tabs)/chat/planner.tsx
+++ b/app/(tabs)/chat/planner.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { View, TextInput, Button, FlatList, Text } from 'react-native';
+
+import { TaggingButton } from '../../../components/TaggingButton';
+import { planner } from '../../../scripts/api/planner';
+import { useChatStore } from '../../../store/chatStore';
+
+export default function PlannerChatScreen() {
+  const threadId = 'planner';
+  const { threads, addMessage, loadThread } = useChatStore();
+  const thread = threads[threadId];
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    loadThread(threadId);
+  }, [threadId, loadThread]);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text) return;
+    await addMessage(threadId, { role: 'user', content: text });
+    const messages = useChatStore.getState().threads[threadId].messages;
+    const reply = await planner(messages);
+    await addMessage(threadId, { role: 'assistant', content: reply });
+    setInput('');
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={thread?.messages ?? []}
+        keyExtractor={(_, idx) => idx.toString()}
+        renderItem={({ item }) => (
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <Text style={{ flex: 1 }}>
+              {item.role}: {item.content}
+            </Text>
+            <TaggingButton />
+          </View>
+        )}
+      />
+      <TextInput
+        value={input}
+        onChangeText={setInput}
+        placeholder="Type your message"
+        style={{ borderWidth: 1, borderColor: '#ccc', marginBottom: 8, padding: 8 }}
+      />
+      <Button title="Send" onPress={handleSend} />
+    </View>
+  );
+}
+

--- a/app/(tabs)/chat/tutor.tsx
+++ b/app/(tabs)/chat/tutor.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { View, TextInput, Button, FlatList, Text } from 'react-native';
+
+import { TaggingButton } from '../../../components/TaggingButton';
+import { tutor } from '../../../scripts/api/tutor';
+import { useChatStore } from '../../../store/chatStore';
+
+export default function TutorChatScreen() {
+  const threadId = 'tutor';
+  const { threads, addMessage, loadThread } = useChatStore();
+  const thread = threads[threadId];
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    loadThread(threadId);
+  }, [threadId, loadThread]);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text) return;
+    await addMessage(threadId, { role: 'user', content: text });
+    const messages = useChatStore.getState().threads[threadId].messages;
+    const reply = await tutor(messages);
+    await addMessage(threadId, { role: 'assistant', content: reply });
+    setInput('');
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={thread?.messages ?? []}
+        keyExtractor={(_, idx) => idx.toString()}
+        renderItem={({ item }) => (
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <Text style={{ flex: 1 }}>
+              {item.role}: {item.content}
+            </Text>
+            <TaggingButton />
+          </View>
+        )}
+      />
+      <TextInput
+        value={input}
+        onChangeText={setInput}
+        placeholder="Type your message"
+        style={{ borderWidth: 1, borderColor: '#ccc', marginBottom: 8, padding: 8 }}
+      />
+      <Button title="Send" onPress={handleSend} />
+    </View>
+  );
+}
+

--- a/store/chatStore.ts
+++ b/store/chatStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AgentType } from '../scripts/api/types';
 
 export type ChatMessage = {
@@ -15,13 +16,35 @@ export interface ChatThread {
 interface ChatState {
   threads: Record<string, ChatThread>;
   createThread: (threadId: string) => void;
-  addMessage: (threadId: string, message: ChatMessage) => void;
+  addMessage: (threadId: string, message: ChatMessage) => Promise<void>;
+  loadThread: (threadId: string) => Promise<void>;
   setAgentType: (threadId: string, agent: AgentType) => void;
   getThread: (threadId: string) => ChatThread | undefined;
 }
 
 export const useChatStore = create<ChatState>((set, get) => ({
   threads: {},
+  loadThread: async (threadId) => {
+    const existing = get().threads[threadId];
+    if (existing) return;
+    const stored = await AsyncStorage.getItem(`thread-${threadId}`);
+    if (stored) {
+      const messages: ChatMessage[] = JSON.parse(stored);
+      set((state) => ({
+        threads: {
+          ...state.threads,
+          [threadId]: { threadId, messages },
+        },
+      }));
+    } else {
+      set((state) => ({
+        threads: {
+          ...state.threads,
+          [threadId]: { threadId, messages: [] },
+        },
+      }));
+    }
+  },
   createThread: (threadId) => {
     const existing = get().threads[threadId];
     if (existing) return;
@@ -32,17 +55,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
       },
     }));
   },
-  addMessage: (threadId, message) => {
+  addMessage: async (threadId, message) => {
     const current = get().threads[threadId] ?? { threadId, messages: [] };
+    const updated: ChatThread = {
+      ...current,
+      messages: [...current.messages, message],
+    };
     set((state) => ({
       threads: {
         ...state.threads,
-        [threadId]: {
-          ...current,
-          messages: [...current.messages, message],
-        },
+        [threadId]: updated,
       },
     }));
+    await AsyncStorage.setItem(
+      `thread-${threadId}`,
+      JSON.stringify(updated.messages)
+    );
   },
   setAgentType: (threadId, agent) =>
     set((state) => {


### PR DESCRIPTION
## Summary
- add dedicated chat screens for tutor, counselor, and planner
- persist thread messages in AsyncStorage through chat store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo not found; attempted `npm install` but dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_689e39909b88832bacf6955d85e0ed60