### PR TITLE
feat: add chat model abstractions

### DIFF
--- a/scripts/api/IChatModel.ts
+++ b/scripts/api/IChatModel.ts
@@ -1,0 +1,14 @@
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export interface IChatModel {
+  /**
+   * Sends a prompt to the underlying model.
+   * @param prompt New user prompt to send.
+   * @param history Optional prior messages in the conversation.
+   * @returns Model response as plain text.
+   */
+  send(prompt: string, history?: Message[]): Promise<string>;
+}

--- a/scripts/api/deepseek.ts
+++ b/scripts/api/deepseek.ts
@@ -1,0 +1,34 @@
+import { IChatModel, Message } from './IChatModel';
+
+export class DeepseekChatModel implements IChatModel {
+  private model: string;
+  private apiKey: string;
+  private endpoint: string;
+
+  constructor(model: string = process.env.DEEPSEEK_MODEL || 'deepseek-chat') {
+    this.model = model;
+    this.apiKey = process.env.DEEPSEEK_API_KEY || '';
+    this.endpoint =
+      process.env.DEEPSEEK_ENDPOINT || 'https://api.deepseek.com/chat/completions';
+  }
+
+  async send(prompt: string, history: Message[] = []): Promise<string> {
+    const res = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [...history, { role: 'user', content: prompt }],
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Deepseek API error: ${res.status}`);
+    }
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content ?? '';
+  }
+}

--- a/scripts/api/gemini.ts
+++ b/scripts/api/gemini.ts
@@ -1,0 +1,19 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { IChatModel, Message } from './IChatModel';
+
+export class GeminiChatModel implements IChatModel {
+  private model: ReturnType<GoogleGenerativeAI['getGenerativeModel']>;
+
+  constructor(model: string = process.env.GEMINI_MODEL || 'gemini-1.5-flash') {
+    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+    this.model = genAI.getGenerativeModel({ model });
+  }
+
+  async send(prompt: string, history: Message[] = []): Promise<string> {
+    const chat = this.model.startChat({
+      history: history.map((m) => ({ role: m.role, parts: [{ text: m.content }] })),
+    });
+    const res = await chat.sendMessage(prompt);
+    return res.response.text() ?? '';
+  }
+}

--- a/scripts/api/getChatModel.ts
+++ b/scripts/api/getChatModel.ts
@@ -1,0 +1,31 @@
+import { AgentType } from './types';
+import { IChatModel } from './IChatModel';
+import { OpenAIChatModel } from './openai';
+import { GeminiChatModel } from './gemini';
+import { DeepseekChatModel } from './deepseek';
+
+/**
+ * Returns a chat model instance based on the current plan or agent type.
+ * The provider can be configured via env variables:
+ * - `<AGENT>_PROVIDER` (e.g. TUTOR_PROVIDER="gemini")
+ * - `CHAT_PROVIDER` for a global default provider
+ *
+ * Model names can be overridden via `<AGENT>_MODEL` env variables.
+ */
+export function getChatModel(agentType: AgentType): IChatModel {
+  const providerKey = `${agentType.toUpperCase()}_PROVIDER`;
+  const provider =
+    (process.env[providerKey] || process.env.CHAT_PROVIDER || 'openai').toLowerCase();
+
+  const modelKey = `${agentType.toUpperCase()}_MODEL`;
+  const model = process.env[modelKey];
+
+  switch (provider) {
+    case 'gemini':
+      return new GeminiChatModel(model);
+    case 'deepseek':
+      return new DeepseekChatModel(model);
+    default:
+      return new OpenAIChatModel(model);
+  }
+}

--- a/scripts/api/openai.ts
+++ b/scripts/api/openai.ts
@@ -1,0 +1,23 @@
+import OpenAI from 'openai';
+import { IChatModel, Message } from './IChatModel';
+
+export class OpenAIChatModel implements IChatModel {
+  private client: OpenAI;
+  private model: string;
+
+  constructor(model: string = process.env.OPENAI_MODEL || 'gpt-4o-mini') {
+    this.client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    this.model = model;
+  }
+
+  async send(prompt: string, history: Message[] = []): Promise<string> {
+    const res = await this.client.responses.create({
+      model: this.model,
+      input: [
+        ...history.map((m) => ({ role: m.role, content: m.content })),
+        { role: 'user', content: prompt },
+      ],
+    });
+    return res.output_text ?? '';
+  }
+}


### PR DESCRIPTION
## Summary
- add `IChatModel` interface
- implement OpenAI, Gemini, and Deepseek chat model classes
- provide `getChatModel` factory to select provider per agent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e3d97a84c832b812550d9498aa14d