### PR TITLE
refactor: fix component imports

### DIFF
--- a/app/(tabs)/chat/counselor.tsx
+++ b/app/(tabs)/chat/counselor.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { View, TextInput, Button, FlatList, Text } from 'react-native';
 
-import { TaggingButton } from '../../../components/TaggingButton';
-import { counselor } from '../../../scripts/api/counselor';
-import { useChatStore } from '../../../store/chatStore';
+import { TaggingButton } from '@/components/TaggingButton';
+import { counselor } from '@/scripts/api/counselor';
+import { useChatStore } from '@/store/chatStore';
 
 export default function CounselorChatScreen() {
   const threadId = 'counselor';

--- a/app/(tabs)/chat/new.tsx
+++ b/app/(tabs)/chat/new.tsx
@@ -2,11 +2,11 @@ import React, { useRef, useState } from 'react';
 import { View, TextInput, Button, FlatList, Text } from 'react-native';
 import { nanoid } from 'nanoid';
 
-import { tutor } from '../../../scripts/api/tutor';
-import { counselor } from '../../../scripts/api/counselor';
-import { planner } from '../../../scripts/api/planner';
-import { AgentType } from '../../../scripts/api/types';
-import { useChatStore, ChatMessage } from '../../../store/chatStore';
+import { tutor } from '@/scripts/api/tutor';
+import { counselor } from '@/scripts/api/counselor';
+import { planner } from '@/scripts/api/planner';
+import { AgentType } from '@/scripts/api/types';
+import { useChatStore, ChatMessage } from '@/store/chatStore';
 
 const agentClients: Record<AgentType, (msgs: ChatMessage[]) => Promise<string>> = {
   tutor,

--- a/app/(tabs)/chat/planner.tsx
+++ b/app/(tabs)/chat/planner.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { View, TextInput, Button, FlatList, Text } from 'react-native';
 
-import { TaggingButton } from '../../../components/TaggingButton';
-import { planner } from '../../../scripts/api/planner';
-import { useChatStore } from '../../../store/chatStore';
+import { TaggingButton } from '@/components/TaggingButton';
+import { planner } from '@/scripts/api/planner';
+import { useChatStore } from '@/store/chatStore';
 
 export default function PlannerChatScreen() {
   const threadId = 'planner';

--- a/app/(tabs)/chat/tutor.tsx
+++ b/app/(tabs)/chat/tutor.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { View, TextInput, Button, FlatList, Text } from 'react-native';
 
-import { TaggingButton } from '../../../components/TaggingButton';
-import { tutor } from '../../../scripts/api/tutor';
-import { useChatStore } from '../../../store/chatStore';
+import { TaggingButton } from '@/components/TaggingButton';
+import { tutor } from '@/scripts/api/tutor';
+import { useChatStore } from '@/store/chatStore';
 
 export default function TutorChatScreen() {
   const threadId = 'tutor';

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,9 +5,9 @@ import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { ChatSendButton } from '../../components/ChatSendButton';
-import { TaggingButton } from '../../components/TaggingButton';
-import { ReportButton } from '../../components/ReportButton';
+import { ChatSendButton } from '@/components/ChatSendButton';
+import { TaggingButton } from '@/components/TaggingButton';
+import { ReportButton } from '@/components/ReportButton';
 
 export default function HomeScreen() {
   return (

--- a/components/ChatSendButton.tsx
+++ b/components/ChatSendButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Alert } from 'react-native';
-import { logEvent } from '../scripts/supabase';
+import { logEvent } from '@/scripts/supabase';
 
 export function ChatSendButton() {
   const handlePress = async () => {

--- a/components/ReportButton.tsx
+++ b/components/ReportButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Alert } from 'react-native';
-import { logEvent } from '../scripts/supabase';
+import { logEvent } from '@/scripts/supabase';
 
 export function ReportButton() {
   const handlePress = async () => {

--- a/components/TaggingButton.tsx
+++ b/components/TaggingButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Alert } from 'react-native';
-import { logEvent } from '../scripts/supabase';
+import { logEvent } from '@/scripts/supabase';
 
 export function TaggingButton() {
   const handlePress = async () => {


### PR DESCRIPTION
## Summary
- replace relative component paths with project alias
- align chat screens with alias imports for components and APIs

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e478a9d4c832ba01af3c5011e3410